### PR TITLE
Add onFill to allow overriding the filled value

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -1912,14 +1912,10 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             if (gridSelection.current === undefined) return;
             const v: EditListItem[] = [];
             const r = gridSelection.current.range;
-            let selectedCells;
+            let selectedCells: CellArray | undefined;
             if (onFill !== undefined && getCellsForSelection !== undefined) {
-                let thunk = getCellsForSelection(r, abortControllerRef.current.signal);
-                if (typeof thunk !== "object") {
-                    selectedCells = await thunk();
-                } else {
-                    selectedCells = thunk;
-                }
+                const thunk = getCellsForSelection(r, abortControllerRef.current.signal);
+                selectedCells = typeof thunk !== "object" ? (await thunk()) : thunk;
             }
             for (let x = 0; x < r.width; x++) {
                 const fillCol = x + r.x;
@@ -1951,7 +1947,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 }))
             );
         },
-        [getMangledCellContent, gridSelection, mangledOnCellsEdited, onFill]
+        [getCellsForSelection, getMangledCellContent, gridSelection, mangledOnCellsEdited, onFill, rowMarkerOffset]
     );
 
     const isPrevented = React.useRef(false);
@@ -2021,7 +2017,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             if (isOutside) return;
 
             if (mouse?.fillHandle === true && gridSelection.current !== undefined) {
-                fillDown(gridSelection.current.cell[1] !== gridSelection.current.range.y);
+                void fillDown(gridSelection.current.cell[1] !== gridSelection.current.range.y);
                 return;
             }
 
@@ -2828,7 +2824,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     gridSelection.current.range.height > 1
                 ) {
                     // ctrl/cmd + d
-                    fillDown(false);
+                    void fillDown(false);
                     cancel();
                 } else if (
                     keybindings.rightFill &&

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -2471,6 +2471,47 @@ describe("data-editor", () => {
         expect(multiSpy).toHaveBeenCalled();
     });
 
+    test("onFill is called when filling down", async () => {
+        const onCellEdited = jest.fn();
+        const onCellsEdited = jest.fn();
+        const onFill = jest.fn();
+        jest.useFakeTimers();
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                keybindings={{ downFill: true }}
+                onCellEdited={onCellEdited}
+                onCellsEdited={onCellsEdited}
+                onFill={onFill}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep();
+        const canvas = screen.getByTestId("data-grid-canvas");
+
+        sendClick(canvas, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 * 2 + 16, // Row 2 (0 indexed)
+        });
+
+        sendClick(canvas, {
+            shiftKey: true,
+            clientX: 400, // Col C
+            clientY: 36 + 32 * 6 + 16, // Row 6 (0 indexed)
+        });
+
+        fireEvent.keyDown(canvas, {
+            keyCode: 68,
+            ctrlKey: true,
+        });
+
+        expect(onCellEdited).toHaveBeenCalledTimes(8);
+        expect(onCellsEdited).toHaveBeenCalled();
+        expect(onFill).toHaveBeenCalledTimes(8);
+    });
+
     test("Fill right", async () => {
         const spy = jest.fn();
         const multiSpy = jest.fn();
@@ -2507,6 +2548,47 @@ describe("data-editor", () => {
 
         expect(spy).toHaveBeenCalledTimes(5);
         expect(multiSpy).toHaveBeenCalled();
+    });
+
+    test("onFill is called when filling right", async () => {
+        const onCellEdited = jest.fn();
+        const onCellsEdited = jest.fn();
+        const onFill = jest.fn();
+        jest.useFakeTimers();
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                keybindings={{ rightFill: true }}
+                onCellEdited={onCellEdited}
+                onCellsEdited={onCellsEdited}
+                onFill={onFill}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep();
+        const canvas = screen.getByTestId("data-grid-canvas");
+
+        sendClick(canvas, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 * 2 + 16, // Row 2 (0 indexed)
+        });
+
+        sendClick(canvas, {
+            shiftKey: true,
+            clientX: 400, // Col C
+            clientY: 36 + 32 * 6 + 16, // Row 6 (0 indexed)
+        });
+
+        fireEvent.keyDown(canvas, {
+            keyCode: 82,
+            ctrlKey: true,
+        });
+
+        expect(onCellEdited).toHaveBeenCalledTimes(5);
+        expect(onCellsEdited).toHaveBeenCalled();
+        expect(onFill).toHaveBeenCalledTimes(5);
     });
 
     test("Clear selection", async () => {


### PR DESCRIPTION
I want to use this like:
```js
  const calculateFill = React.useCallback((fillValue: EditableGridCell, colBefore: any[], targetOffset: number) => {
    if (colBefore.length >= 2 && typeof colBefore[0] === 'number' && typeof colBefore[1] === 'number') {
      // Assume arithmetic series
      const seriesOffset = colBefore[1] - colBefore[0]
      fillValue.data = colBefore[0] + targetOffset * seriesOffset
      return fillValue
    }
  }, [])
  const onFill = React.useCallback(
    (fillValue: ReadWriteGridCell, targetCell: Item, selectedCells?: CellArray) => {
      if (selectedCells && selection?.current?.range) {
        const targetCol = targetCell[0] - selection.current.range.x
        const colBefore = selectedCells.map(r => r[targetCol]?.data)
        return calculateFill(fillValue, colBefore, targetCell[1] - selection.current.range.y)
      }
    },
    [selection, calculateFill]
  )
  ```
  
  to get arithmetic series expanded when filling instead of always getting the value from the top cell.