### PR TITLE
Improve dropdown cell

### DIFF
--- a/packages/cells/src/cell.stories.tsx
+++ b/packages/cells/src/cell.stories.tsx
@@ -178,6 +178,7 @@ export const CustomCells: React.VFC = () => {
                 onPaste={true}
                 // eslint-disable-next-line no-console
                 onCellEdited={(...args) => console.log("Edit Cell", ...args)}
+                getCellsForSelection={true}
                 getCellContent={cell => {
                     const [col, row] = cell;
                     if (col === 0) {

--- a/packages/cells/src/cell.stories.tsx
+++ b/packages/cells/src/cell.stories.tsx
@@ -398,8 +398,8 @@ export const CustomCells: React.VFC = () => {
                         width: 150,
                     },
                     {
+                        id: "dropdown",
                         title: "Dropdown",
-                        width: 150,
                     },
                     {
                         title: "Range",

--- a/packages/cells/src/cells/dropdown-cell.tsx
+++ b/packages/cells/src/cells/dropdown-cell.tsx
@@ -20,8 +20,8 @@ const CustomMenu: React.FC<CustomMenuProps> = p => {
 
 interface DropdownCellProps {
     readonly kind: "dropdown-cell";
-    readonly value: string;
-    readonly allowedValues: readonly string[];
+    readonly value: string | undefined | null;
+    readonly allowedValues: readonly (string | undefined | null)[];
     readonly readonly?: boolean;
 }
 
@@ -154,17 +154,19 @@ const renderer: CustomRenderer<DropdownCell> = {
     draw: (args, cell) => {
         const { ctx, theme, rect } = args;
         const { value } = cell.data;
-        ctx.fillStyle = theme.textDark;
-        ctx.fillText(
-            value,
-            rect.x + theme.cellHorizontalPadding,
-            rect.y + rect.height / 2 + getMiddleCenterBias(ctx, theme)
-        );
-
+        if (value) {
+            ctx.fillStyle = theme.textDark;
+            ctx.fillText(
+                value,
+                rect.x + theme.cellHorizontalPadding,
+                rect.y + rect.height / 2 + getMiddleCenterBias(ctx, theme)
+            );
+        }
         return true;
     },
     measure: (ctx, cell) => {
         const { value } = cell.data;
+        if (value === null || value === undefined) return 16;
         return ctx.measureText(value).width + 16;
     },
     provideEditor: () => ({

--- a/packages/cells/src/cells/dropdown-cell.tsx
+++ b/packages/cells/src/cells/dropdown-cell.tsx
@@ -166,8 +166,11 @@ const renderer: CustomRenderer<DropdownCell> = {
     },
     measure: (ctx, cell) => {
         const { value } = cell.data;
-        if (value === null || value === undefined) return 16;
-        return ctx.measureText(value).width + 16;
+        if (value) {
+            return ctx.measureText(value).width + 16;
+        } else {
+            return 16;
+        }
     },
     provideEditor: () => ({
         editor: Editor,

--- a/packages/cells/src/cells/dropdown-cell.tsx
+++ b/packages/cells/src/cells/dropdown-cell.tsx
@@ -81,6 +81,17 @@ const Editor: ReturnType<ProvideEditorCallback<DropdownCell>> = p => {
                         border: 0,
                         boxShadow: "none",
                     }),
+                    option: base => ({
+                        ...base,
+                        fontSize: theme.editorFontSize,
+                        fontFamily: theme.fontFamily,
+                        // Add some content in case the option is empty
+                        // so that the option height can be calculated correctly
+                        ":empty::after": {
+                            content: '"&nbsp;"',
+                            visibility: "hidden",
+                        },
+                    }),
                 }}
                 theme={t => {
                     return {
@@ -151,6 +162,10 @@ const renderer: CustomRenderer<DropdownCell> = {
         );
 
         return true;
+    },
+    measure: (ctx, cell) => {
+        const { value } = cell.data;
+        return ctx.measureText(value).width + 16;
     },
     provideEditor: () => ({
         editor: Editor,

--- a/packages/cells/src/cells/dropdown-cell.tsx
+++ b/packages/cells/src/cells/dropdown-cell.tsx
@@ -5,6 +5,7 @@ import {
     getMiddleCenterBias,
     useTheme,
     GridCellKind,
+    TextCellEntry,
 } from "@glideapps/glide-data-grid";
 import { styled } from "@linaria/react";
 import * as React from "react";
@@ -22,7 +23,6 @@ interface DropdownCellProps {
     readonly kind: "dropdown-cell";
     readonly value: string | undefined | null;
     readonly allowedValues: readonly (string | undefined | null)[];
-    readonly readonly?: boolean;
 }
 
 export type DropdownCell = CustomCell<DropdownCellProps>;
@@ -49,6 +49,14 @@ const PortalWrap = styled.div`
     }
 `;
 
+// This is required since the padding is disabled for this cell type
+// The settings are based on the "pad" settings in the data-grid-overlay-editor-style.tsx
+const ReadOnlyWrap = styled.div`
+    display: "flex";
+    margin: auto 8.5px;
+    padding-bottom: 3px;
+`;
+
 const Editor: ReturnType<ProvideEditorCallback<DropdownCell>> = p => {
     const { value: cell, onFinishedEditing, initialValue } = p;
     const { allowedValues, value: valueIn } = cell.data;
@@ -66,6 +74,20 @@ const Editor: ReturnType<ProvideEditorCallback<DropdownCell>> = p => {
             })),
         [allowedValues]
     );
+
+    if (cell.readonly) {
+        return (
+            <ReadOnlyWrap>
+                <TextCellEntry
+                    highlight={true}
+                    autoFocus={false}
+                    disabled={true}
+                    value={value ?? ""}
+                    onChange={() => undefined}
+                />
+            </ReadOnlyWrap>
+        );
+    }
 
     return (
         <Wrap>


### PR DESCRIPTION
This PR adds the following improvements to the dropdown cell:
1) Use the defined font size and family for the menu options
2) If the value is empty -> add an invisible string to enable correct height measuring for the option item. 
3) Implement the `measure` method to enable the auto-sizing feature for this cell.
4) Add support for the `readonly` property. If `readonly==True`, return a read-only TextCellEntry instead.
4) Allow undefined and null as values.

Before:
<img width="97" alt="Screenshot 2023-03-03 at 01 40 05" src="https://user-images.githubusercontent.com/2852129/222605485-c534ea9d-63ec-4c3a-8e90-32b7e8862ac4.png">

After:
<img width="93" alt="Screenshot 2023-03-03 at 01 40 32" src="https://user-images.githubusercontent.com/2852129/222605497-395be51b-ea66-49f8-8f86-6500a8a0ad93.png">

