### PR TITLE
feat: expose the cell location in keyboard event

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3400,6 +3400,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             shiftKey: false,
                             altKey: false,
                             rawEvent: undefined,
+                            location: {},
                         });
                         break;
                     case "fill-right":
@@ -3415,6 +3416,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             shiftKey: false,
                             altKey: false,
                             rawEvent: undefined,
+                            location: {},
                         });
                         break;
                     case "fill-down":
@@ -3430,6 +3432,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             shiftKey: false,
                             altKey: false,
                             rawEvent: undefined,
+                            location: {},
                         });
                         break;
                     case "copy":

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3431,7 +3431,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             shiftKey: false,
                             altKey: false,
                             rawEvent: undefined,
-                            location: {},
+                            location: undefined,
                         });
                         break;
                     case "fill-right":
@@ -3447,7 +3447,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             shiftKey: false,
                             altKey: false,
                             rawEvent: undefined,
-                            location: {},
+                            location: undefined,
                         });
                         break;
                     case "fill-down":
@@ -3463,7 +3463,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             shiftKey: false,
                             altKey: false,
                             rawEvent: undefined,
-                            location: {},
+                            location: undefined,
                         });
                         break;
                     case "copy":

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -141,6 +141,7 @@ export interface GridKeyEventArgs {
     readonly stopPropagation: () => void;
     readonly preventDefault: () => void;
     readonly rawEvent: React.KeyboardEvent<HTMLElement> | undefined;
+    readonly location: { col?: number; row?: number };
 }
 
 interface DragHandler {

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -141,7 +141,7 @@ export interface GridKeyEventArgs {
     readonly stopPropagation: () => void;
     readonly preventDefault: () => void;
     readonly rawEvent: React.KeyboardEvent<HTMLElement> | undefined;
-    readonly location: { col?: number; row?: number };
+    readonly location: Item | undefined;
 }
 
 interface DragHandler {

--- a/packages/core/src/data-grid/data-grid.tsx
+++ b/packages/core/src/data-grid/data-grid.tsx
@@ -1168,11 +1168,10 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             if (canvas === null) return;
 
             let bounds: Rectangle | undefined;
-            const location: { col?: number; row?: number } = {};
+            let location: Item | undefined = undefined;
             if (selection.current !== undefined) {
                 bounds = getBoundsForItem(canvas, selection.current.cell[0], selection.current.cell[1]);
-                location.col = selection.current.cell[0];
-                location.row = selection.current.cell[1];
+                location = selection.current.cell;
             }
 
             onKeyDown?.({
@@ -1199,11 +1198,10 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             if (canvas === null) return;
 
             let bounds: Rectangle | undefined;
-            const location: { col?: number; row?: number } = {};
+            let location: Item | undefined = undefined;
             if (selection.current !== undefined) {
                 bounds = getBoundsForItem(canvas, selection.current.cell[0], selection.current.cell[1]);
-                location.col = selection.current.cell[0];
-                location.row = selection.current.cell[1];
+                location = selection.current.cell;
             }
 
             onKeyUp?.({
@@ -1564,7 +1562,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                                         row >= range.y &&
                                         row < range.y + range.height;
                                     const id = `glide-cell-${col}-${row}`;
-                                    const cellContent = getCellContent([col, row], true);
+                                    const location: Item = [col, row];
+                                    const cellContent = getCellContent(location, true);
                                     return (
                                         <td
                                             key={key}
@@ -1591,7 +1590,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                                                     shiftKey: false,
                                                     altKey: false,
                                                     rawEvent: undefined,
-                                                    location: { col, row },
+                                                    location,
                                                 });
                                             }}
                                             onFocusCapture={e => {
@@ -1601,8 +1600,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                                                         lastFocusedSubdomNode.current?.[1] === row)
                                                 )
                                                     return;
-                                                lastFocusedSubdomNode.current = [col, row];
-                                                return onCellFocused?.([col, row]);
+                                                lastFocusedSubdomNode.current = location;
+                                                return onCellFocused?.(location);
                                             }}
                                             ref={focused ? focusElement : undefined}
                                             tabIndex={-1}>

--- a/packages/core/src/data-grid/data-grid.tsx
+++ b/packages/core/src/data-grid/data-grid.tsx
@@ -1129,8 +1129,11 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             if (canvas === null) return;
 
             let bounds: Rectangle | undefined;
+            const location: { col?: number; row?: number } = {};
             if (selection.current !== undefined) {
                 bounds = getBoundsForItem(canvas, selection.current.cell[0], selection.current.cell[1]);
+                location.col = selection.current.cell[0];
+                location.row = selection.current.cell[1];
             }
 
             onKeyDown?.({
@@ -1145,6 +1148,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                 key: event.key,
                 keyCode: event.keyCode,
                 rawEvent: event,
+                location,
             });
         },
         [onKeyDown, selection, getBoundsForItem]
@@ -1156,8 +1160,11 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             if (canvas === null) return;
 
             let bounds: Rectangle | undefined;
+            const location: { col?: number; row?: number } = {};
             if (selection.current !== undefined) {
                 bounds = getBoundsForItem(canvas, selection.current.cell[0], selection.current.cell[1]);
+                location.col = selection.current.cell[0];
+                location.row = selection.current.cell[1];
             }
 
             onKeyUp?.({
@@ -1172,6 +1179,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                 key: event.key,
                 keyCode: event.keyCode,
                 rawEvent: event,
+                location,
             });
         },
         [onKeyUp, selection, getBoundsForItem]
@@ -1544,6 +1552,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                                                     shiftKey: false,
                                                     altKey: false,
                                                     rawEvent: undefined,
+                                                    location: { col, row },
                                                 });
                                             }}
                                             onFocusCapture={e => {

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -804,8 +804,12 @@ describe("data-editor", () => {
     test("keyDown and keyUp events include the cell location", async () => {
         let keyDownEvent: GridKeyEventArgs | undefined;
         let keyUpEvent: GridKeyEventArgs | undefined;
-        const keyDown = (e: GridKeyEventArgs) => { keyDownEvent = e; };
-        const keyUp = (e: GridKeyEventArgs) => { keyUpEvent = e; };
+        const keyDown = (e: GridKeyEventArgs) => {
+            keyDownEvent = e;
+        };
+        const keyUp = (e: GridKeyEventArgs) => {
+            keyUpEvent = e;
+        };
 
         jest.useFakeTimers();
         render(<DataEditor {...basicProps} onKeyDown={keyDown} onKeyUp={keyUp} />, {
@@ -829,8 +833,8 @@ describe("data-editor", () => {
 
         jest.runAllTimers();
 
-        expect(keyDownEvent?.location).toEqual({"col": 1, "row": 1});
-        expect(keyUpEvent?.location).toEqual({"col": 1, "row": 1});
+        expect(keyDownEvent?.location).toEqual([1, 1]);
+        expect(keyUpEvent?.location).toEqual([1, 1]);
     });
 
     test("Doesn't emit cell click if mouseDown happened in a different cell", async () => {

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -11,7 +11,7 @@ import {
     isSizedGridColumn,
     Item,
 } from "../src";
-import type { CustomCell, SizedGridColumn } from "../src/data-grid/data-grid-types";
+import type { CustomCell, GridKeyEventArgs, SizedGridColumn } from "../src/data-grid/data-grid-types";
 import type { DataEditorRef } from "../src/data-editor/data-editor";
 import { assert } from "../src/common/support";
 
@@ -702,6 +702,38 @@ describe("data-editor", () => {
 
         expect(spy).toHaveBeenCalled();
         expect(spy).toHaveBeenCalledWith([1, 1]);
+    });
+
+    test("keyDown and keyUp events include the cell location", async () => {
+        let keyDownEvent: GridKeyEventArgs | undefined;
+        let keyUpEvent: GridKeyEventArgs | undefined;
+        const keyDown = (e: GridKeyEventArgs) => { keyDownEvent = e; };
+        const keyUp = (e: GridKeyEventArgs) => { keyUpEvent = e; };
+
+        jest.useFakeTimers();
+        render(<DataEditor {...basicProps} onKeyDown={keyDown} onKeyUp={keyUp} />, {
+            wrapper: Context,
+        });
+        prep(false);
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+        sendClick(canvas, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 + 16, // Row 1 (0 indexed)
+        });
+
+        fireEvent.keyDown(canvas, {
+            key: " ",
+        });
+
+        fireEvent.keyUp(canvas, {
+            key: " ",
+        });
+
+        jest.runAllTimers();
+
+        expect(keyDownEvent?.location).toEqual({"col": 1, "row": 1});
+        expect(keyUpEvent?.location).toEqual({"col": 1, "row": 1});
     });
 
     test("Doesn't emit cell click if mouseDown happened in a different cell", async () => {


### PR DESCRIPTION
While implementing custom hotkeys, it's useful to have an access to the cell, on which the keyboard event occurred.
E.g. adding new row when CMD+Enter was pressed on the last row