### PR TITLE
Fix issue with missing ts distribution in cells package

### DIFF
--- a/packages/cells/tsconfig.types.json
+++ b/packages/cells/tsconfig.types.json
@@ -13,5 +13,12 @@
         "emitDeclarationOnly": true,
         "sourceMap": false
     },
-    "exclude": ["./src/**/*.stories.tsx", "./src/stories/*.tsx", "./src/docs/*.tsx", "./src/setupTests.ts",]
+    "exclude": [
+        "./src/**/*.stories.tsx",
+        "./src/stories/*.tsx",
+        "./src/docs/*.tsx",
+        "./src/setupTests.ts",
+        "./test/**/*.test.ts",
+        "./test/**/*.test.tsx"
+    ]
 }


### PR DESCRIPTION
`5.2.2-beta3` and `5.2.2-beta4` do not contain a valid `ts` distribution for the `cells` package. The reason is that the files are within the `src` folder instead of in the `dist/ts` root: 

![Screenshot 2023-03-21 at 12 58 25](https://user-images.githubusercontent.com/2852129/226620306-7eaaf49a-5678-4898-874b-c0fdd5d2a8ed.png)


This is `5.2.2-beta2` which still works fine for me:

![Screenshot 2023-03-21 at 12 56 20](https://user-images.githubusercontent.com/2852129/226620244-47b34421-dc01-4ce2-b0d1-19f86400a53b.png)

This happened after the tests were added to the `cells` packages. I believe we need to exclude the files from the test folder in `tsconfig.types.json`. 

I'm also not sure if the test folder needs to be added to the include here?

https://github.com/glideapps/glide-data-grid/blob/e3b3507c1e00c71ff79cd23a792e43f2933a7b41/packages/cells/tsconfig.json#L3
