### PR TITLE
fix: removed duplicate event listeners

### DIFF
--- a/packages/core/src/click-outside-container/click-outside-container.tsx
+++ b/packages/core/src/click-outside-container/click-outside-container.tsx
@@ -12,8 +12,8 @@ export default class ClickOutsideContainer extends React.PureComponent<Props> {
     }
 
     public componentWillUnmount() {
-        document.removeEventListener("mousedown", this.clickOutside);
-        document.removeEventListener("contextmenu", this.clickOutside);
+        document.removeEventListener("mousedown", this.clickOutside, true);
+        document.removeEventListener("contextmenu", this.clickOutside, true);
     }
 
     private clickOutside = (event: MouseEvent) => {


### PR DESCRIPTION
`document.addEventListener` is used with `useCapture: true`, but `document.removeEventListener` is used without it, so the listener stays.
This MR fixes the issue