### PR TITLE
allow custom editor to choose movement via onFinishedEditing

### DIFF
--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -506,19 +506,29 @@ onVisibleRegionChanged?: (range: Rectangle) => void;
 ## provideEditor
 
 ```ts
-interface EditorProps {
-    readonly onChange: (newValue: GridCell) => void;
-    readonly onFinishedEditing: (newValue?: GridCell) => void;
+export type ProvideEditorComponent<T extends InnerGridCell> = React.FunctionComponent<{
+    readonly onChange: (newValue: T) => void;
+    readonly onFinishedEditing: (newValue?: T, movement?: readonly [-1 | 0 | 1, -1 | 0 | 1]) => void;
     readonly isHighlighted: boolean;
-    readonly value: GridCell;
-}
+    readonly value: T;
+    readonly initialValue?: string;
+    readonly validatedSelection?: SelectionRange;
+    readonly imageEditorOverride?: ImageEditorType;
+    readonly markdownDivCreateNode?: (content: string) => DocumentFragment;
+    readonly target: Rectangle;
+    readonly forceEditMode: boolean;
+    readonly isValid?: boolean;
+}>;
 
-type ProvideEditorCallback = (cell: GridCell) =>
-    (React.FunctionComponent<EditorProps> & {
+export type ProvideEditorCallbackResult<T extends InnerGridCell> =
+    | (ProvideEditorComponent<T> & {
           disablePadding?: boolean;
           disableStyling?: boolean;
       })
+    | ObjectEditorCallbackResult<T>
     | undefined;
+
+export type ProvideEditorCallback<T extends InnerGridCell> = (cell: T) => ProvideEditorCallbackResult<T>;
 
 provideEditor?: ProvideEditorCallback<GridCell>;
 ```

--- a/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx
+++ b/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx
@@ -106,8 +106,8 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
     }, [tempValue, onFinishEditing]);
 
     const onEditorFinished = React.useCallback(
-        (newValue: GridCell | undefined) => {
-            onFinishEditing(newValue, customMotion.current ?? [0, 0]);
+        (newValue: GridCell | undefined, movement?: readonly [-1 | 0 | 1, -1 | 0 | 1]) => {
+            onFinishEditing(newValue, movement ?? customMotion.current ?? [0, 0]);
             finished.current = true;
         },
         [onFinishEditing]

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -467,7 +467,7 @@ export type SelectionRange = number | readonly [number, number];
 /** @category Renderers */
 export type ProvideEditorComponent<T extends InnerGridCell> = React.FunctionComponent<{
     readonly onChange: (newValue: T) => void;
-    readonly onFinishedEditing: (newValue?: T) => void;
+    readonly onFinishedEditing: (newValue?: T, movement?: readonly [-1 | 0 | 1, -1 | 0 | 1]) => void;
     readonly isHighlighted: boolean;
     readonly value: T;
     readonly initialValue?: string;


### PR DESCRIPTION
Want to support typical spreadsheet editing movements like
- Shift+Enter: Move selection up after closing editor
- Shift+Tab Move selection left after closing editor
- Arrow-up: Move selection up after closing editor if formula is plain text
- Arrow-left, Arrow-down, Arrow-right: same as above for other directions

In general, think it should be left up to developers to decide which direction to go to using the new `onFinishedEditing`, and deprecate the default `onKeyDown` for custom editors.

```
<div className="clip-region" onKeyDown={onKeyDown}>
  {editor}
</div>
```
