### PR TITLE
Fix smart-mode sorting for date-like columns with `useColumnSort`

### DIFF
--- a/packages/source/src/use-column-sort.test.tsx
+++ b/packages/source/src/use-column-sort.test.tsx
@@ -1,0 +1,41 @@
+import { compareSmart } from "./use-column-sort";
+
+describe('use-column-sort', () => {
+
+    describe('compareSmart', function () {
+
+        test('it does not parse date formats into numbers when sorting', function () {
+            expect([
+                '2022-02-01',
+                '2023-01-01',
+                '2024-01-01',
+            ].sort(compareSmart)).toEqual([
+                '2022-02-01',
+                '2023-01-01',
+                '2024-01-01',
+            ])
+
+            expect([
+                '2024-12-01',
+                '2022-12-01',
+                '2023-12-01',
+            ].sort(compareSmart)).toEqual([
+                '2022-12-01',
+                '2023-12-01',
+                '2024-12-01',
+            ])
+
+            // This is where parseFloat() starts to fool us
+            expect([
+                '2022-12-03',
+                '2022-12-01',
+                '2022-12-02',
+            ].sort(compareSmart)).toEqual([
+                '2022-12-01',
+                '2022-12-02',
+                '2022-12-03',
+            ])
+        });
+    });
+
+});

--- a/packages/source/src/use-column-sort.ts
+++ b/packages/source/src/use-column-sort.ts
@@ -29,7 +29,7 @@ function cellToSortData(c: GridCell): string {
 function tryParse(val: string | number): number | string {
     if (typeof val === "number") return val;
     if (val.length > 0) {
-        const x = parseFloat(val);
+        const x = Number(val);
         if (!isNaN(x)) {
             val = x;
         }


### PR DESCRIPTION
I ran across an issue with the `useColumnSort` hook from the data-source package.

When sorting columns with dates on the format `YYYY-MM-DD`, `parseFloat` would treat them as numbers, which results in what looks like a broken sort order.

Example:
```js
> parseFloat('2022-01-01')
2022
> parseFloat('2022-01-03')
2022
```

I suggest switching to using the `Number` constructor instead, as it provides results like this:
```
> Number('2022-01-03')
NaN
```

Cheers,
Anton