### PR TITLE
feat: pass through middle mouse click event to onCellClicked

### DIFF
--- a/packages/core/src/common/resize-detector.ts
+++ b/packages/core/src/common/resize-detector.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
-import { useLayoutEffect, useState, useRef, MutableRefObject } from "react";
+import { useLayoutEffect, useState, useRef, type MutableRefObject } from "react";
 interface ReactResizeDetectorDimensions {
     height?: number;
     width?: number;

--- a/packages/core/src/common/resize-detector.ts
+++ b/packages/core/src/common/resize-detector.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
-import { useLayoutEffect, useState, useRef, type MutableRefObject } from "react";
+import { useLayoutEffect, useState, useRef, MutableRefObject } from "react";
 interface ReactResizeDetectorDimensions {
     height?: number;
     width?: number;

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -2032,6 +2032,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         preventDefault,
                     });
                 }
+                if (a.button === 1) return !isPrevented.current;
                 if (!isPrevented.current) {
                     const c = getMangledCellContent(args.location);
                     const r = getCellRenderer(c);

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -1821,7 +1821,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         (args: GridMouseEventArgs) => {
             isPrevented.current = false;
             touchDownArgs.current = visibleRegionRef.current;
-            if (args.button !== 0) {
+            if (args.button !== 0 && args.button !== 1) {
                 mouseDownData.current = undefined;
                 return;
             }
@@ -2130,7 +2130,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 }
             }
 
-            if (args.kind === "cell" && args.button === 0) {
+            if (args.kind === "cell" && (args.button === 0 || args.button === 1)) {
                 handleMaybeClick(args);
             }
 

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -1821,12 +1821,13 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         ]
     );
     const isActivelyDraggingHeader = React.useRef(false);
-    const lastMouseSelectLocation = React.useRef<[number, number]>();
+    const lastMouseSelectLocation = React.useRef<readonly [number, number]>();
     const touchDownArgs = React.useRef(visibleRegion);
     const mouseDownData =
         React.useRef<{
             wasDoubleClick: boolean;
             time: number;
+            button: number;
             location: Item;
         }>();
     const onMouseDown = React.useCallback(
@@ -1842,6 +1843,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             const wasDoubleClick = time - (mouseDownData.current?.time ?? -1000) < 250;
             mouseDownData.current = {
                 wasDoubleClick,
+                button: args.button,
                 time,
                 location: args.location,
             };
@@ -1860,8 +1862,10 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             });
             lastMouseSelectLocation.current = undefined;
 
-            if (!args.isTouch) {
+            if (!args.isTouch && args.button === 0) {
                 handleSelect(args);
+            } else if (!args.isTouch && args.button === 1) {
+                lastMouseSelectLocation.current = args.location;
             }
         },
         [gridSelection, handleSelect]
@@ -2294,6 +2298,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
     const onItemHoveredImpl = React.useCallback(
         (args: GridMouseEventArgs) => {
+            if (mouseDownData?.current?.button !== undefined && mouseDownData.current.button >= 1) return;
             if (
                 mouseState !== undefined &&
                 mouseDownData.current?.location[0] === 0 &&

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -3239,7 +3239,7 @@ describe("data-editor", () => {
         });
     });
 
-    test.only("Select range with mouse middle click fails", async () => {
+    test("Select range with mouse middle click fails", async () => {
         const spy = jest.fn();
         jest.useFakeTimers();
         render(<EventedDataEditor {...basicProps} onGridSelectionChange={spy} />, {

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -477,6 +477,37 @@ describe("data-editor", () => {
         expect(spySelection).not.toHaveBeenCalled();
     });
 
+    test("middle click does not change selection", async () => {
+        const spySelection = jest.fn();
+
+        jest.useFakeTimers();
+        render(
+            <DataEditor
+                {...basicProps}
+                gridSelection={{
+                    columns: CompactSelection.empty(),
+                    rows: CompactSelection.empty(),
+                }}
+                onGridSelectionChange={spySelection}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep();
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+
+        screen.getByTestId("data-grid-canvas");
+        sendClick(canvas, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 + 16, // Row 1 (0 indexed)
+            button: 1,
+        });
+
+        expect(spySelection).not.toHaveBeenCalled();
+    });
+
     test("emits contextmenu for cell but does not change selection if already selected - current.cell", async () => {
         const spy = jest.fn();
         const spySelection = jest.fn();
@@ -3201,6 +3232,41 @@ describe("data-editor", () => {
                 current: { cell: [1, 2], range: { height: 11, width: 3, x: 1, y: 2 }, rangeStack: [] },
             })
         );
+
+        fireEvent.mouseUp(canvas, {
+            clientX: 600, // Col B
+            clientY: 36 + 32 * 12 + 16, // Row 2
+        });
+    });
+
+    test.only("Select range with mouse middle click fails", async () => {
+        const spy = jest.fn();
+        jest.useFakeTimers();
+        render(<EventedDataEditor {...basicProps} onGridSelectionChange={spy} />, {
+            wrapper: Context,
+        });
+        prep();
+        const canvas = screen.getByTestId("data-grid-canvas");
+
+        sendClick(canvas, {
+            button: 0,
+            clientX: 300, // Col B
+            clientY: 36 + 32 * 2 + 16, // Row 2
+        });
+
+        fireEvent.mouseDown(canvas, {
+            button: 1,
+            clientX: 300, // Col B
+            clientY: 36 + 32 * 2 + 16, // Row 2
+        });
+
+        spy.mockClear();
+        fireEvent.mouseMove(canvas, {
+            clientX: 600, // Col B
+            clientY: 36 + 32 * 12 + 16, // Row 2
+        });
+
+        expect(spy).not.toBeCalled();
 
         fireEvent.mouseUp(canvas, {
             clientX: 600, // Col B

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -607,6 +607,47 @@ describe("data-editor", () => {
         expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
     });
 
+    test("Emits cell clicked with middle button", async () => {
+        const spy = jest.fn();
+
+        jest.useFakeTimers();
+        render(<DataEditor {...basicProps} onCellClicked={spy} />, {
+            wrapper: Context,
+        });
+        prep();
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+
+        sendClick(canvas, {
+            button: 1,
+            clientX: 300, // Col B
+            clientY: 36 + 32 + 16, // Row 1 (0 indexed)
+        });
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+    });
+
+    test("Does not emits cell clicked with back button", async () => {
+        const spy = jest.fn();
+
+        jest.useFakeTimers();
+        render(<DataEditor {...basicProps} onCellClicked={spy} />, {
+            wrapper: Context,
+        });
+        prep();
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+
+        sendClick(canvas, {
+            button: 4,
+            clientX: 300, // Col B
+            clientY: 36 + 32 + 16, // Row 1 (0 indexed)
+        });
+
+        expect(spy).not.toHaveBeenCalled();
+    });
+
     test("Emits cell click with touch", async () => {
         const spy = jest.fn();
 
@@ -652,6 +693,31 @@ describe("data-editor", () => {
 
         expect(spy).toHaveBeenCalled();
         expect(spy).toHaveBeenCalledWith([1, 1]);
+    });
+
+    test("Does not emit activated event on double click with different buttons", async () => {
+        const spy = jest.fn();
+
+        jest.useFakeTimers();
+        render(<DataEditor {...basicProps} onCellActivated={spy} />, {
+            wrapper: Context,
+        });
+        prep();
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+        sendClick(canvas, {
+            button: 0,
+            clientX: 300, // Col B
+            clientY: 36 + 32 + 16, // Row 1 (0 indexed)
+        });
+
+        sendClick(canvas, {
+            button: 1,
+            clientX: 300, // Col B
+            clientY: 36 + 32 + 16, // Row 1 (0 indexed)
+        });
+
+        expect(spy).not.toHaveBeenCalled();
     });
 
     test("Emits activated event on Enter key", async () => {
@@ -3949,12 +4015,9 @@ describe("data-editor", () => {
         spy.mockClear();
 
         jest.useFakeTimers();
-        render(
-            <DataEditor {...basicProps} />,
-            {
-                wrapper: Context,
-            }
-        );
+        render(<DataEditor {...basicProps} />, {
+            wrapper: Context,
+        });
         prep();
 
         const canvas = screen.getByTestId("data-grid-canvas");


### PR DESCRIPTION
# Current State

Currently only the left mouse button event (`button === 0`) is being passed through to the mouse event handler `handleMaybeClick`.

# Proposed Change

Also pass through the middle mouse button through to the cell `onCellClicked` event handler to allow for different behaviors between the two mouse buttons.

cc @jassmith @ivoelbert 