### PR TITLE
Fix rendering of narrow drilldown cells

### DIFF
--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -1001,10 +1001,11 @@ export function drawDrilldownCell(args: BaseDrawArgs, data: readonly DrilldownCe
         for (const rectInfo of renderBoxes) {
             const rx = Math.floor(rectInfo.x);
             const rw = Math.floor(rectInfo.width);
+            const outerMiddleWidth = rw - (outerSideWidth - outerPadding) * 2
             ctx.imageSmoothingEnabled = false;
 
             ctx.drawImage(el, 0, 0, sideWidth, height, rx - outerPadding, y, outerSideWidth, h);
-            if (rectInfo.width > sideWidth * 2)
+            if (outerMiddleWidth > 0)
                 ctx.drawImage(
                     el,
                     sideWidth,
@@ -1013,7 +1014,7 @@ export function drawDrilldownCell(args: BaseDrawArgs, data: readonly DrilldownCe
                     height,
                     rx + (outerSideWidth - outerPadding),
                     y,
-                    rw - (outerSideWidth - outerPadding) * 2,
+                    outerMiddleWidth,
                     h
                 );
             ctx.drawImage(


### PR DESCRIPTION
Our team noticed that for narrower drilldown cells, the middle of the pill border/shadow was missing.

<img width="241" alt="drilldown@2x" src="https://github.com/glideapps/glide-data-grid/assets/94077014/f1450e7c-f06f-4615-8a8e-da6494c10dcb">

I noticed that this varied depending on the `devicePixelRatio`; less frequent for a DPR 1 and more frequent for DPR 4

1x | 2x | 4x |
|-|-|-|
| <img width="231" alt="drilldown@1x" src="https://github.com/glideapps/glide-data-grid/assets/94077014/544aa66a-befb-4f63-9159-495afc5af16e"> | <img width="241" alt="drilldown@2x" src="https://github.com/glideapps/glide-data-grid/assets/94077014/274ce251-5909-4702-95d9-da6b423a3c80"> | <img width="231" alt="drilldown@4x" src="https://github.com/glideapps/glide-data-grid/assets/94077014/cf444933-6b4f-4f16-bb86-4798b86a1775"> |


So I was thinking this `rectInfo.width > sideWidth * 2` needed to become `rectInfo.width > outerSideWidth * 2` (which accounts for the dpr)

https://github.com/glideapps/glide-data-grid/blob/c9e1f3df5d545171ccca2226c0c55e253fb6cc83/packages/core/src/data-grid/data-grid-lib.ts#L1001-L1018

This fixed a lot of the cases, but still wasn't working for extremely narrow cells.

<img width="300" alt="still not quite fixed" src="https://github.com/glideapps/glide-data-grid/assets/94077014/2b1c7882-ee04-43cd-8207-cc603c3dd7cb">

I think this is because `bubbleHeight` is being used in places where a `bubbleWidth` should really be calculated instead.

I tried reworking this logic a few times, but in the end I realized that the conditional middle draw correctly calculates its with for the drawing using `rw - (outerSideWidth - outerPadding) * 2` so I pulled this out into a new `const outerMiddleWidth` and just check `outerMiddleWidth > 0`, which seems to work in all of my testing.