### PR TITLE
fix: allow measureCell to handle custom cell types

### DIFF
--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -5,7 +5,6 @@ import type { GetCellRendererCallback } from "../data-grid/cells/cell-types";
 import {
     CellArray,
     GridCell,
-    GridCellKind,
     GridColumn,
     InnerGridColumn,
     isSizedGridColumn,
@@ -22,7 +21,7 @@ function measureCell(
     getCellRenderer: GetCellRendererCallback
 ): number {
     const r = getCellRenderer(cell);
-    return ('measure' in r && r?.measure?.(ctx, cell, theme)) ?? defaultSize;
+    return r?.measure?.(ctx, cell, theme) ?? defaultSize;
 }
 
 export function measureColumn(

--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -132,7 +132,6 @@ export function useColumnSizer(
                 }
             }
             lastColumns.current = columns;
-            console.log("Setting selection data");
             setSelectionData(toSet);
         };
         void fn();

--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -132,6 +132,7 @@ export function useColumnSizer(
                 }
             }
             lastColumns.current = columns;
+            console.log("Setting selection data");
             setSelectionData(toSet);
         };
         void fn();

--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -21,10 +21,8 @@ function measureCell(
     theme: Theme,
     getCellRenderer: GetCellRendererCallback
 ): number {
-    if (cell.kind === GridCellKind.Custom) return defaultSize;
-
     const r = getCellRenderer(cell);
-    return r?.measure?.(ctx, cell, theme) ?? defaultSize;
+    return ('measure' in r && r?.measure?.(ctx, cell, theme)) ?? defaultSize;
 }
 
 export function measureColumn(


### PR DESCRIPTION
[Issue this PR is addressing](https://github.com/glideapps/glide-data-grid/issues/697)

Problem:
The current `measureCell` function that is used to determine the size of a cell based on various content uses a `defaultValue` of 150px when it encounters a cell type of `GridCellKind.Custom`. This causes all of the custom cell type to arbitrarily auto adjust the custom cell columns to be 150px no matter what.

Proposal:
Remove the custom cell type guard to allow custom cells to define their own `measure` callback to handle how they want to be measured.