### PR TITLE
Remove row change from OneMillionRows example

### DIFF
--- a/packages/core/src/docs/examples/one-million-rows.stories.tsx
+++ b/packages/core/src/docs/examples/one-million-rows.stories.tsx
@@ -24,20 +24,13 @@ export default {
 export const OneMillionRows: React.VFC = () => {
     const { cols, getCellContent } = useMockDataGenerator(6);
 
-    const [rows, setRows] = React.useState(1_000_000);
-
-    React.useEffect(() => {
-        window.setTimeout(() => setRows(5), 3000);
-    }, []);
-
     return (
         <DataEditor
             {...defaultProps}
-            height="100%"
             getCellContent={getCellContent}
             columns={cols}
             rowHeight={31}
-            rows={rows}
+            rows={1_000_000}
             rowMarkers="number"
         />
     );


### PR DESCRIPTION
Pretty sure this `window.setTimeout(() => setRows(5), 3000);` in https://github.com/glideapps/glide-data-grid/commit/caad51c217f79b66777d66a0a14cf984ffba9e46 was left over from testing clearing ghost selection. This changes the `OneMillionRows` back to what it was before that.