### PR TITLE
Add canvas cleanup for useColumnSizer()

### DIFF
--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -78,15 +78,21 @@ export function useColumnSizer(
     getCellsForSelectionRef.current = getCellsForSelection;
     themeRef.current = theme;
 
-    const [ctx] = React.useState(() => {
-        if (typeof window === "undefined") return null;
+    const [canvas, ctx] = React.useMemo(() => {
+        if (typeof window === "undefined") return [null, null];
         const offscreen = document.createElement("canvas");
         offscreen.style["display"] = "none";
         offscreen.style["opacity"] = "0";
         offscreen.style["position"] = "fixed";
-        document.documentElement.append(offscreen);
-        return offscreen.getContext("2d", { alpha: false });
-    });
+        return [offscreen, offscreen.getContext("2d", { alpha: false })];
+    }, []);
+
+    React.useLayoutEffect(() => {
+        if (canvas) document.documentElement.append(canvas);
+        return () => {
+            canvas?.remove();
+        };
+    }, [canvas]);
 
     const memoMap = React.useRef<Record<string, number>>({});
 


### PR DESCRIPTION
#711 noticed that some of the canvas elements created by the grid were not being cleaned up. I looked into it and discovered that while most of them are being cleaned up (e.g. `DataGrid`'s `bufferA` and `bufferB`)

https://github.com/glideapps/glide-data-grid/blob/c9e1f3df5d545171ccca2226c0c55e253fb6cc83/packages/core/src/data-grid/data-grid.tsx#L637-L647

the same was not being done for the `offscreen` canvas in `useColumnSizer()`

https://github.com/glideapps/glide-data-grid/blob/c9e1f3df5d545171ccca2226c0c55e253fb6cc83/packages/core/src/data-editor/use-column-sizer.ts#L81-L89

I adapted the `useEffectLayout()` and cleanup logic from the former to use in the latter.

---

# Before: Canvases being left behind with each Show/Hide

https://github.com/glideapps/glide-data-grid/assets/94077014/57e74d4a-0b98-4b4c-b918-1e0ccc45f633

# After: All canvases are cleaned up after each Show/Hide

https://github.com/glideapps/glide-data-grid/assets/94077014/78c5e04f-a07e-4bae-a411-faa728ae3317

---

Side note: I noticed there are three places where canvases are getting created with essentially `style="display: none; opacity: 0; position: fixed;`. Maybe this should be consolidated in a helper function?

Not sure how much of a performance concern it is, but there appear to be a number of places where `document.createElement("canvas")` is called such as any time `normalSizeColumn()` gets called or its dependencies (such as `columns`, `mergedTheme` or `rows` among others) change, any time `LinkCell`'s `onSelect` or `onClick` get called. And canvases are retained for each sprite of each fg/bg color and dpr, and for each bg color, border style, dpr and height of each drill down border.