### PR TITLE
fix: typescript types exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "types": "dist/ts/index.d.ts",
     "exports": {
         ".": {
+            "types": "./dist/ts/index.d.ts",
             "import": "./dist/js/index.js",
             "require": "./dist/cjs/index.js"
         },


### PR DESCRIPTION
On node 18 with typescript 5.1.6, the types aren't resolved, this ensure they  are picked.

BTW I just found out this incredible project, I'm pretty interested in providing some help on the publish side / ci / qa. Would you be interested ?



### Useful tools

- https://publint.dev/@glideapps/glide-data-grid@5.2.1
- https://arethetypeswrong.github.io/?p=%40glideapps%2Fglide-data-grid%405.2.1

Both provides cli tools that can be run locally (ci checks...)