### PR TITLE
fix: disable autoscrolling when dragging column headers

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -1818,7 +1818,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             themeForCell,
         ]
     );
-
+    const isActivelyDraggingHeader = React.useRef(false);
     const lastMouseSelectLocation = React.useRef<[number, number]>();
     const touchDownArgs = React.useRef(visibleRegion);
     const mouseDownData =
@@ -1843,6 +1843,10 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 time,
                 location: args.location,
             };
+
+            if (args?.kind === "header") {
+                isActivelyDraggingHeader.current = true;
+            }
 
             const fh = args.kind === "cell" && args.isFillHandle;
 
@@ -2003,6 +2007,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             const mouse = mouseState;
             setMouseState(undefined);
             setScrollDir(undefined);
+            isActivelyDraggingHeader.current = false;
 
             if (isOutside) return;
 
@@ -2177,6 +2182,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             };
             onMouseMove?.(a);
             setScrollDir(cv => {
+                if (isActivelyDraggingHeader.current) return [args.scrollEdge[0], 0];
                 if (args.scrollEdge[0] === cv?.[0] && args.scrollEdge[1] === cv[1]) return cv;
                 return mouseState === undefined || (mouseDownData.current?.location[0] ?? 0) < rowMarkerOffset
                     ? undefined

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -3841,6 +3841,40 @@ describe("data-editor", () => {
         expect(spy).not.toHaveBeenCalled();
     });
 
+    test("Dragging header disables vertical autoscroll", async () => {
+        const spy = Element.prototype.scrollBy as jest.Mock;
+        spy.mockClear();
+
+        jest.useFakeTimers();
+        render(
+            <DataEditor {...basicProps} />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep();
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+        fireEvent.mouseDown(canvas, {
+            clientX: 300, // Col B
+            clientY: 16, // Header
+        });
+
+        fireEvent.mouseMove(canvas, {
+            clientX: 300, // Col B
+            clientY: 0,
+        });
+
+        await new Promise(r => window.setTimeout(r, 100));
+
+        fireEvent.mouseUp(canvas, {
+            clientX: 300, // Col B
+            clientY: 0,
+        });
+
+        expect(spy).not.toHaveBeenCalled();
+    });
+
     test("Use fill handle", async () => {
         const spy = jest.fn();
         jest.useFakeTimers();


### PR DESCRIPTION
[Issue](https://github.com/quicktype/glide-data-grid/issues/754)

Problem:
Currently, pressing down and holding a column header will cause the table to unexpectedly vertically scroll scroll.  

An example can be seen below: 

https://github.com/quicktype/glide-data-grid/assets/103522725/7656a4db-a9ae-48a0-9e52-f7f835eebdda

Proposal:
Update the `onMouseMove` logic to so that the table does not scroll vertically when a column header is pressed down. Horizontal scrolling within the table should still be enabled so that users can properly drag and drop column headers.

This PR accomplishes the above by storing and checking when a `header` is being pressed down, if a `header` is being pressed, then we only track the horizontal scroll direction but do not set a vertical scroll direction. 